### PR TITLE
Add vector field visualizer with animation

### DIFF
--- a/codex_test_MathApp/ContentView.swift
+++ b/codex_test_MathApp/ContentView.swift
@@ -6,16 +6,78 @@
 //
 
 import SwiftUI
+import WebKit
+
+/// Main content view used during early prototyping.
+/// Displays a text field for entering a vector field expression
+/// and shows a simple evaluation result to confirm parsing works.
 
 struct ContentView: View {
+    /// Raw text entered by the user representing the vector field.
+    @State private var inputText: String = "(-y, x)"
+    /// Currently parsed vector field.
+    @State private var vectorField: VectorField = VectorField(text: "(-y, x)")
+    /// Selected path type for line integral demonstration.
+    @State private var pathType: PathType = .circle
+    /// Animation progress along the path [0,1].
+    @State private var progress: CGFloat = 0
+    /// Whether the path animation is active.
+    @State private var isAnimating = false
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Vector Field Input")
+                .font(.headline)
+
+            TextField("e.g. (-y, x)", text: $inputText)
+                .textFieldStyle(.roundedBorder)
+
+            Button("Parse") {
+                vectorField = VectorField(text: inputText)
+            }
+            .buttonStyle(.borderedProminent)
+
+            Picker("Path", selection: $pathType) {
+                ForEach(PathType.allCases) { type in
+                    Text(type.rawValue.capitalized).tag(type)
+                }
+            }
+            .pickerStyle(.segmented)
+
+            VectorFieldCanvas(field: vectorField)
+                .overlay(
+                    GeometryReader { geo in
+                        pathType.path(in: geo.frame(in: .local))
+                            .stroke(Color.red, lineWidth: 2)
+                        let point = pathType.point(t: progress, in: geo.frame(in: .local))
+                        Circle()
+                            .fill(Color.green)
+                            .frame(width: 8, height: 8)
+                            .position(point)
+                        let integral = vectorField.lineIntegral(path: pathType, samples: 100, size: geo.size)
+                        Text(String(format: "∮F·dr ≈ %.2f", integral))
+                            .position(x: geo.size.width - 80, y: 20)
+                    }
+                )
+
+            Button(isAnimating ? "Stop" : "Start") {
+                isAnimating.toggle()
+            }
+            .buttonStyle(.bordered)
+
+            Text("Evaluation at x=1, y=1:")
+            let value = vectorField.evaluate(x: 1, y: 1)
+            Text("(\(value.0), \(value.1))")
+                .monospaced()
+
+            MathJaxView(latex: "\\oint \mathbf{F}\cdot d\mathbf{r}")
         }
         .padding()
+        .onReceive(Timer.publish(every: 0.02, on: .main, in: .common).autoconnect()) { _ in
+            guard isAnimating else { return }
+            progress += 0.002
+            if progress > 1 { progress = 0 }
+        }
     }
 }
 

--- a/codex_test_MathApp/ExpressionParser.swift
+++ b/codex_test_MathApp/ExpressionParser.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Represents a single scalar expression parsed via `NSExpression`.
+/// This supports variables `x` and `y` and basic arithmetic operators.
+struct ParsedExpression {
+    let expressionString: String
+    private let nsExpression: NSExpression
+
+    init(string: String) {
+        self.expressionString = string
+        // `NSExpression` will parse the expression for us.
+        self.nsExpression = NSExpression(format: string)
+    }
+
+    /// Evaluates the expression with provided x and y values.
+    func evaluate(x: Double, y: Double) -> Double {
+        let variables: [String: Double] = ["x": x, "y": y]
+        return nsExpression.expressionValue(with: variables, context: nil) as? Double ?? .nan
+    }
+}
+
+/// Simple representation of a 2D vector field of the form `(fx, fy)`.
+struct VectorField {
+    var rawText: String
+    var fx: ParsedExpression
+    var fy: ParsedExpression
+
+    init(text: String) {
+        self.rawText = text
+        let sanitized = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        var body = sanitized
+        // remove surrounding parentheses if present
+        if body.hasPrefix("(") && body.hasSuffix(")") {
+            body.removeFirst()
+            body.removeLast()
+        }
+        let parts = body.split(separator: ",", maxSplits: 1).map { $0.trimmingCharacters(in: .whitespaces) }
+        let fxText = parts.count > 0 ? String(parts[0]) : "0"
+        let fyText = parts.count > 1 ? String(parts[1]) : "0"
+        self.fx = ParsedExpression(string: fxText)
+        self.fy = ParsedExpression(string: fyText)
+    }
+
+    func evaluate(x: Double, y: Double) -> (Double, Double) {
+        (fx.evaluate(x: x, y: y), fy.evaluate(x: x, y: y))
+    }
+}
+

--- a/codex_test_MathApp/MathJaxView.swift
+++ b/codex_test_MathApp/MathJaxView.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+import WebKit
+
+/// Simple WebView wrapper that loads MathJax to render LaTeX strings.
+struct MathJaxView: UIViewRepresentable {
+    let latex: String
+
+    func makeUIView(context: Context) -> WKWebView {
+        return WKWebView()
+    }
+
+    func updateUIView(_ uiView: WKWebView, context: Context) {
+        let html = """
+        <html>
+        <head>
+        <script src='https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js'></script>
+        </head>
+        <body style='font-size:150%;'>
+        $$\(latex)$$
+        </body>
+        </html>
+        """
+        uiView.loadHTMLString(html, baseURL: nil)
+    }
+}

--- a/codex_test_MathApp/PathModels.swift
+++ b/codex_test_MathApp/PathModels.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+/// Available parametric paths for integration animations.
+enum PathType: String, CaseIterable, Identifiable {
+    case circle
+    case line
+
+    var id: String { rawValue }
+
+    /// Returns a path within the given size used for drawing and sampling.
+    func path(in rect: CGRect) -> Path {
+        switch self {
+        case .circle:
+            return Path { p in
+                p.addEllipse(in: rect.insetBy(dx: rect.width * 0.2, dy: rect.height * 0.2))
+            }
+        case .line:
+            return Path { p in
+                let start = CGPoint(x: rect.minX + rect.width * 0.2,
+                                     y: rect.midY)
+                let end = CGPoint(x: rect.maxX - rect.width * 0.2,
+                                   y: rect.midY)
+                p.move(to: start)
+                p.addLine(to: end)
+            }
+        }
+    }
+
+    /// Sample a point on the path for t in [0,1].
+    func point(t: CGFloat, in rect: CGRect) -> CGPoint {
+        let path = self.path(in: rect)
+        switch self {
+        case .circle:
+            let center = CGPoint(x: rect.midX, y: rect.midY)
+            let radius = min(rect.width, rect.height) * 0.3
+            let angle = 2 * .pi * t
+            return CGPoint(x: center.x + radius * cos(angle),
+                           y: center.y + radius * sin(angle))
+        case .line:
+            let start = CGPoint(x: rect.minX + rect.width * 0.2,
+                                 y: rect.midY)
+            let end = CGPoint(x: rect.maxX - rect.width * 0.2,
+                               y: rect.midY)
+            return CGPoint(x: start.x + (end.x - start.x) * t,
+                           y: start.y + (end.y - start.y) * t)
+        }
+    }
+
+    /// Tangent vector for t in [0,1]. Used for line integral dot product.
+    func tangent(t: CGFloat, in rect: CGRect) -> CGPoint {
+        switch self {
+        case .circle:
+            let radius = min(rect.width, rect.height) * 0.3
+            let angle = 2 * .pi * t
+            return CGPoint(x: -radius * sin(angle) * 2 * .pi,
+                           y: radius * cos(angle) * 2 * .pi)
+        case .line:
+            let start = CGPoint(x: rect.minX + rect.width * 0.2,
+                                 y: rect.midY)
+            let end = CGPoint(x: rect.maxX - rect.width * 0.2,
+                               y: rect.midY)
+            return CGPoint(x: end.x - start.x, y: end.y - start.y)
+        }
+    }
+}

--- a/codex_test_MathApp/VectorField+Integrals.swift
+++ b/codex_test_MathApp/VectorField+Integrals.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+extension VectorField {
+    /// Approximate line integral over a parametric path defined by point(t) and tangent(t)
+    /// using simple Riemann sum with n samples.
+    func lineIntegral(path: PathType, samples n: Int, size: CGSize) -> Double {
+        guard n > 1 else { return 0 }
+        var total: Double = 0
+        let rect = CGRect(origin: .zero, size: size)
+        for i in 0..<n {
+            let t = CGFloat(i) / CGFloat(n - 1)
+            let point = path.point(t: t, in: rect)
+            let tangent = path.tangent(t: t, in: rect)
+            let fx = evaluate(x: Double((point.x - size.width/2)/40),
+                              y: Double((size.height/2 - point.y)/40))
+            let vector = CGPoint(x: fx.0, y: fx.1)
+            let dot = Double(vector.x * tangent.x + vector.y * tangent.y)
+            total += dot
+        }
+        // scale step length
+        return total / Double(n)
+    }
+}

--- a/codex_test_MathApp/VectorFieldCanvas.swift
+++ b/codex_test_MathApp/VectorFieldCanvas.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+/// Canvas view that draws a simple representation of a vector field in 2D.
+/// The field is sampled on a grid and small arrows are drawn for the vectors.
+struct VectorFieldCanvas: View {
+    var field: VectorField
+
+    var body: some View {
+        GeometryReader { geometry in
+            Canvas { context, size in
+                let step: CGFloat = 40
+                let center = CGPoint(x: size.width / 2, y: size.height / 2)
+                for x in stride(from: 0, to: size.width, by: step) {
+                    for y in stride(from: 0, to: size.height, by: step) {
+                        let px = x - center.x
+                        let py = center.y - y
+                        let v = field.evaluate(x: Double(px / 40), y: Double(py / 40))
+                        let start = CGPoint(x: x, y: y)
+                        let end = CGPoint(x: start.x + CGFloat(v.0) * 10,
+                                         y: start.y - CGFloat(v.1) * 10)
+                        var path = Path()
+                        path.move(to: start)
+                        path.addLine(to: end)
+                        context.stroke(path, with: .color(.blue), lineWidth: 1)
+                    }
+                }
+            }
+        }
+        .frame(height: 200)
+    }
+}
+
+#Preview {
+    VectorFieldCanvas(field: VectorField(text: "(-y, x)"))
+}

--- a/codex_test_MathAppTests/codex_test_MathAppTests.swift
+++ b/codex_test_MathAppTests/codex_test_MathAppTests.swift
@@ -13,5 +13,12 @@ struct codex_test_MathAppTests {
     @Test func example() async throws {
         // Write your test here and use APIs like `#expect(...)` to check expected conditions.
     }
+    @Test func parserWorks() async throws {
+        let field = VectorField(text: "(-y, x)")
+        let result = field.evaluate(x: 1, y: 1)
+        #expect(result.0 == -1)
+        #expect(result.1 == 1)
+    }
+
 
 }


### PR DESCRIPTION
## Summary
- draw vector fields on a SwiftUI Canvas
- allow path selection and animate a point along the path
- approximate the line integral and show the result
- embed MathJax for formula rendering

## Testing
- `swift --version`
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684028457da0832ba960026a4514e8f6